### PR TITLE
Fix enhanced privacy mode

### DIFF
--- a/Classes/Utility/Twitter.php
+++ b/Classes/Utility/Twitter.php
@@ -310,7 +310,7 @@ class Twitter
      */
     protected function saveTweetPicturesLocally(array &$tweets)
     {
-        foreach ($tweets as $tweet) {
+        foreach ($tweets as &$tweet) {
             if (!empty($tweet['user']['profile_image_url'])) {
                 $tweet['user']['profile_image_url'] = $this->saveUserPic($tweet['user']['profile_image_url']);
             }


### PR DESCRIPTION
To make the enhanced privacy mode work you need to pass the tweet array in method `saveTweetPicturesLocally` as reference. Otherwise the value of `profile_image_url` set with the local path.

Fixes #4 