### PR TITLE
Timeline - Exclude Retweets

### DIFF
--- a/Classes/Utility/Twitter.php
+++ b/Classes/Utility/Twitter.php
@@ -106,7 +106,8 @@ class Twitter
                     $limit,
                     $settings['exclude_replies'],
                     $settings['enhanced_privacy'],
-                    $settings['extended_tweet_mode']
+                    $settings['extended_tweet_mode'],
+                    $settings['include_rts']
                 );
                 break;
             case 'search':
@@ -176,6 +177,7 @@ class Twitter
      * @param bool $exclude_replies
      * @param bool $enhanced_privacy
      * @param bool $extended_tweet_mode
+     * @param bool $include_rts
      * @return array
      * @throws ConfigurationException
      * @throws RequestException
@@ -186,7 +188,8 @@ class Twitter
         $limit = null,
         $exclude_replies = false,
         $enhanced_privacy = false,
-        $extended_tweet_mode = true
+        $extended_tweet_mode = true,
+        $include_rts = true
     ) {
         $params = [
             'exclude_replies' => $exclude_replies ? 'true' : 'false',
@@ -203,6 +206,8 @@ class Twitter
         if ($limit) {
             $params['count'] = $limit;
         }
+
+        $params['include_rts'] = $include_rts;
 
         $tweets = $this->getData('statuses/user_timeline', $params);
         if ($enhanced_privacy) {

--- a/Configuration/TypoScript/constants.txt
+++ b/Configuration/TypoScript/constants.txt
@@ -39,5 +39,7 @@ plugin.tx_cwtwitter {
         enhanced_privacy = 0
         # cat=plugin.tx_cwtwitter; type=boolean; label=Enable extended tweet mode (up to 280 chars)
         extended_tweet_mode = 1
+        # cat=plugin.tx_cwtwitter; type=boolean; label=Include retweets
+        include_rts = 1
     }
 }

--- a/Configuration/TypoScript/setup.txt
+++ b/Configuration/TypoScript/setup.txt
@@ -36,6 +36,7 @@ plugin.tx_cwtwitter {
         exclude_replies = {$plugin.tx_cwtwitter.settings.exclude_replies}
         enhanced_privacy = {$plugin.tx_cwtwitter.settings.enhanced_privacy}
         extended_tweet_mode = {$plugin.tx_cwtwitter.settings.extended_tweet_mode}
+        include_rts = {$plugin.tx_cwtwitter.settings.include_rts}
     }
 
     parsers {


### PR DESCRIPTION
I added the option "include_rts" to have the possibility to exlude retweets from the timeline. This option is configurable.